### PR TITLE
Optimize redundant post fetching calls

### DIFF
--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -11,16 +11,13 @@ import { useAuth, usePosts } from '@/hooks';
 
 export default function ProfilePage() {
   const { user, loading: userLoading } = useAuth();
-  const { posts, loading: postsLoading, likePost, unlikePost } = usePosts();
+  const { posts, loading: postsLoading, handleReactionChange, updatePost, deletePost } = usePosts();
 
   const userPosts = posts?.filter(post => post.user?._id === user._id);
 
-  const handleLikeChange = async (postId, reactionType, isActive) => {
-    if (isActive) {
-      await likePost(postId, reactionType);
-    } else {
-      await unlikePost(postId, reactionType);
-    }
+  const handleLikeChange = async (postId, reactionType, isActive, previousUserReaction) => {
+    const payload = { onModel: 'Post', likableId: postId, reactionType, previousUserReaction };
+    await handleReactionChange(payload);
   };
 
 
@@ -122,6 +119,9 @@ export default function ProfilePage() {
                     onLikeChange={handleLikeChange}
                     showOwnerActions={true}
                     currentUserId={user?._id}
+                    onUpdate={updatePost}
+                    onReactionChange={handleReactionChange}
+                    onDelete={deletePost}
                   />
                 ))}
               </div>

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -17,6 +17,9 @@ export default function HomePage() {
     hasMore, 
     fetchPosts, 
     loadMorePosts, 
+    updatePost,
+    handleReactionChange,
+    deletePost,
   } = usePosts();
 
   const { user: currentUser } = useAuth();
@@ -121,6 +124,9 @@ export default function HomePage() {
                   key={post._id}
                   post={post}
                   currentUserId={currentUser?._id}
+                  onUpdate={updatePost}
+                  onReactionChange={handleReactionChange}
+                  onDelete={deletePost}
                 />
               ))}
               

--- a/src/components/features/PostCard.js
+++ b/src/components/features/PostCard.js
@@ -17,7 +17,6 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import LikeButton from './LikeButton';
 import CommentSection from './CommentSection';
 import { cn } from '@/utils';
-import { usePosts } from '@/hooks';
 
 const PostCard = ({ 
   post, 
@@ -25,6 +24,8 @@ const PostCard = ({
   showOwnerActions = false,
   currentUserId,
   onDelete,
+  onUpdate,
+  onReactionChange,
 }) => {
   const [showComments, setShowComments] = useState(false);
   const [isLiked, setIsLiked] = useState(false);
@@ -36,11 +37,7 @@ const PostCard = ({
   const [description, setDescription] = useState(post.description || '');
 
   // console.log(post)
-
-
   const postId = post._id;
-
-  const { updatePost, handleReactionChange } = usePosts();
 
   const handleLikeChange = async (postId, reactionType, isActive, previousUserReaction) => {
     setIsLiked(isActive);
@@ -52,7 +49,7 @@ const PostCard = ({
       onModel: "Post",
     }
     console.log("handleLikeChange", payload);
-    await handleReactionChange(payload);
+    await onReactionChange?.(payload);
   };
 
 
@@ -66,7 +63,7 @@ const PostCard = ({
     e?.preventDefault?.();
     try {
       setIsSubmitting(true);
-      const result = await updatePost(postId, { caption, description });
+      const result = await onUpdate?.(postId, { caption, description });
       if (result?.success) {
         // Optimistically reflect local changes
         setIsEditOpen(false);


### PR DESCRIPTION
Refactor `PostCard` to receive post mutation handlers via props, eliminating redundant `GET /posts` network calls.

The `usePosts` hook, which fetches posts on mount, was being called directly within each `PostCard` component. This led to a separate `/posts` API call for every post rendered on the page, causing significant network overhead. This PR centralizes the `usePosts` hook in parent components like `HomePage` and `ProfilePage`, and passes the required `updatePost`, `handleReactionChange`, and `deletePost` functions down to `PostCard` as props, ensuring posts are fetched only once per page load.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fadd5b3-6396-4fbd-a1f4-4cc651f3e145">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fadd5b3-6396-4fbd-a1f4-4cc651f3e145">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

